### PR TITLE
fix: DownloadMixin に @extend_schema を追加（drf-spectacular 対応）

### DIFF
--- a/apibase/viewsets.py
+++ b/apibase/viewsets.py
@@ -6,13 +6,30 @@ from django.http import Http404
 from django.utils.functional import cached_property
 from django.views import static
 
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import decorators, serializers, status, viewsets
 from rest_framework.response import Response
 
 from . import paginations, permissions, storages, utils
 from .settings import apibase_settings
+
+# OpenAPI schema support (optional)
+try:
+    from drf_spectacular.types import OpenApiTypes
+    from drf_spectacular.utils import OpenApiParameter, extend_schema
+except ImportError:
+
+    def extend_schema(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    class OpenApiParameter:
+        PATH = "path"
+
+    class OpenApiTypes:
+        STR = None
+
 
 logger = getLogger()
 

--- a/apibase/viewsets.py
+++ b/apibase/viewsets.py
@@ -6,6 +6,8 @@ from django.http import Http404
 from django.utils.functional import cached_property
 from django.views import static
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import decorators, serializers, status, viewsets
 from rest_framework.response import Response
 
@@ -39,12 +41,40 @@ def static_serve(request, path, name=None, document_root="/"):
 
 
 class DownloadMixin:
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="field",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="FileField name to download",
+            )
+        ],
+        responses={200: bytes},
+    )
     @decorators.action(methods=["get"], detail=True, url_path="(?P<field>[^/.]+)/download")
     def download_filefield(self, request, pk, format=None, field=None):
         """download FileField file"""
         instance = self.get_object()
         return self.response_field_data(request, instance, field)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="field",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="FileField name to download",
+            ),
+            OpenApiParameter(
+                name="name",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="File path in storage",
+            ),
+        ],
+        responses={200: bytes},
+    )
     @decorators.action(
         methods=["get"],
         detail=False,


### PR DESCRIPTION
## 概要

- `DownloadMixin` の `download_filefield` と `download_filefield_storage` アクションに `@extend_schema` デコレータを追加
- `field` と `name` パスパラメータを明示的に string 型として定義
- drf-spectacular を optional dependency として扱い、インストールされていない場合は no-op フォールバックを使用

## 問題

drf-spectacular で OpenAPI スキーマを生成する際、`BaseModelViewSet` を継承する全ての ViewSet で以下の警告が発生：

```
Warning [XXXViewSet]: could not derive type of path parameter "field" because model "xxx.models.XXX" contained no such field.
```

これは drf-spectacular がモデルフィールドからパラメータ型を推論しようとするが、`field` はメタパラメータ（FileField 属性の名前）であり、実際のモデルフィールドではないため発生する。

## 解決策

両アクションに明示的な `OpenApiParameter` アノテーションを追加：
- `download_filefield`: `field` パラメータをアノテート
- `download_filefield_storage`: `field` と `name` パラメータをアノテート

`serializers.py` の既存パターンに従い、try-except ブロックでインポートをラップ。

## テスト計画

- [x] apibase を使用するプロジェクトでスキーマ生成を実行し、`{field}` パラメータの警告が出ないことを確認
- [x] drf-spectacular がインストールされていない環境でもインポートエラーが発生しないことを確認