### PR TITLE
chore: py.typed マーカー追加で mypy 型情報を有効化

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ all = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["apibase"]
+
 [tool.uv.sources]
 django-channels-graphql-ws = { git = "https://github.com/shiftone-ai/DjangoChannelsGraphqlWs", branch = "feature/py312" }
 djangorestframework-filters = { git = "https://github.com/philipn/django-rest-framework-filters.git" }


### PR DESCRIPTION
## Summary

- PEP 561 準拠の `py.typed` マーカーファイルを `apibase/` に追加
- 下流プロジェクト（taihei-cvm-server 等）で mypy が `apibase` の型情報を認識できるようになる

## 背景

`apibase` に `py.typed` がないため、mypy は `ignore_missing_imports = true` の下で全型を `Any` として扱い、下流で多数の型エラーが発生していた。

## Test plan

- [x] `uv build` でパッケージをビルドし、`py.typed` が含まれることを確認
- [x] 下流プロジェクトで `uv sync` 後に mypy エラーが減少することを確認