### PR TITLE
feat!: auto-register GraphQL form-field converters on apibase import

### DIFF
--- a/apibase/__init__.py
+++ b/apibase/__init__.py
@@ -4,16 +4,17 @@ __version__ = "0.3.0"
 # using ListCharField / ListIntegerField surface the correct GraphQL types
 # (``[String!]`` / ``[Int!]``) instead of falling back to ``String``.
 #
-# Registration is guarded because ``apibase.graphql.converters`` imports
-# ``graphene_django``, which reads Django settings at its own import time.
-# REST-only consumers, packaging scripts, and CLI tools that import
-# ``apibase`` before Django is configured must not crash; in those cases the
-# import is deferred and will run later when something explicitly imports
-# ``apibase.graphql`` (e.g., during URL / schema resolution after Django
-# setup has completed).
-from django.core.exceptions import ImproperlyConfigured  # noqa: E402
+# Only attempt the import when Django settings have been configured.
+# ``apibase.graphql.converters`` imports ``graphene_django``, which reads
+# Django settings at its own import time. REST-only consumers, packaging
+# scripts, and CLI tools that touch ``apibase`` before ``django.setup()``
+# would otherwise crash; in that case registration is deferred and runs
+# when something explicitly imports ``apibase.graphql`` later (e.g., during
+# URL / schema resolution after Django has been set up). Using
+# ``settings.configured`` here -- rather than ``try / except
+# ImproperlyConfigured`` -- avoids silently swallowing real misconfiguration
+# such as an invalid ``DJANGO_SETTINGS_MODULE``.
+from django.conf import settings  # noqa: E402
 
-try:
+if settings.configured:
     from . import graphql  # noqa: F401, E402
-except ImproperlyConfigured:
-    pass

--- a/apibase/__init__.py
+++ b/apibase/__init__.py
@@ -1,1 +1,19 @@
-__version__ = "0.1.0"
+__version__ = "0.3.0"
+
+# Eagerly trigger GraphQL form-field converter registration so that filters
+# using ListCharField / ListIntegerField surface the correct GraphQL types
+# (``[String!]`` / ``[Int!]``) instead of falling back to ``String``.
+#
+# Registration is guarded because ``apibase.graphql.converters`` imports
+# ``graphene_django``, which reads Django settings at its own import time.
+# REST-only consumers, packaging scripts, and CLI tools that import
+# ``apibase`` before Django is configured must not crash; in those cases the
+# import is deferred and will run later when something explicitly imports
+# ``apibase.graphql`` (e.g., during URL / schema resolution after Django
+# setup has completed).
+from django.core.exceptions import ImproperlyConfigured  # noqa: E402
+
+try:
+    from . import graphql  # noqa: F401, E402
+except ImproperlyConfigured:
+    pass

--- a/apibase/graphql/__init__.py
+++ b/apibase/graphql/__init__.py
@@ -1,0 +1,7 @@
+"""apibase GraphQL integration.
+
+Importing this package registers graphene-django form-field converters
+for apibase's custom form fields. See :mod:`apibase.graphql.converters`.
+"""
+
+from . import converters  # noqa: F401  (registers converters on import)

--- a/apibase/graphql/converters.py
+++ b/apibase/graphql/converters.py
@@ -1,0 +1,42 @@
+"""Auto-register graphene-django form-field converters for apibase fields.
+
+Importing this module has a side effect: it registers handlers on
+``graphene_django.forms.converter.convert_form_field`` so that filters
+declared with :class:`apibase.fields.ListCharField`,
+:class:`apibase.fields.ListIntegerField`,
+:class:`apibase.fields.MonthRangeField`, and
+``django_filters.fields.MultipleChoiceField`` get exposed as the correct
+GraphQL list / scalar types instead of falling back to ``String``.
+
+Without these registrations, list-style filters such as
+``employee_kind__in = ListCharInFilter(...)`` are surfaced in the GraphQL
+schema as ``String`` (the default for the underlying ``forms.CharField``
+parent class), which makes them unusable from any GraphQL client because
+the schema rejects list literals at type-validation time.
+"""
+
+import graphene
+from django_filters.fields import MultipleChoiceField
+from graphene_django.forms.converter import convert_form_field
+
+from apibase.fields import ListCharField, ListIntegerField, MonthRangeField
+
+
+@convert_form_field.register(MultipleChoiceField)
+def _convert_multiple_choice(field):
+    return graphene.List(graphene.NonNull(graphene.String), required=field.required)
+
+
+@convert_form_field.register(ListCharField)
+def _convert_list_char(field):
+    return graphene.List(graphene.NonNull(graphene.String), required=field.required)
+
+
+@convert_form_field.register(ListIntegerField)
+def _convert_list_integer(field):
+    return graphene.List(graphene.NonNull(graphene.Int), required=field.required)
+
+
+@convert_form_field.register(MonthRangeField)
+def _convert_month_range(field):
+    return graphene.String(required=field.required)

--- a/apibase/graphql/tests/test_converters.py
+++ b/apibase/graphql/tests/test_converters.py
@@ -1,0 +1,77 @@
+"""Tests for auto-registered graphene-django form-field converters.
+
+The registrations live in :mod:`apibase.graphql.converters` and run as a
+side effect of ``import apibase``. These tests assert that each apibase
+form field class converts to the correct graphene type, which is the
+primary contract relied on by all ``__in`` / ``__nin`` GraphQL filters in
+downstream projects.
+"""
+
+import subprocess
+import sys
+
+import graphene
+from django_filters.fields import MultipleChoiceField
+from graphene_django.forms.converter import convert_form_field
+
+# Importing apibase triggers converter registration.
+import apibase  # noqa: F401
+from apibase.fields import ListCharField, ListIntegerField, MonthRangeField
+
+
+def _unwrap(node):
+    """Drill into a ``graphene.List`` / ``NonNull`` wrapper one level."""
+    return getattr(node, "_of_type", None) or getattr(node, "of_type", None)
+
+
+def _assert_list_of_non_null(converted, inner_scalar):
+    """Assert ``converted`` represents ``[inner_scalar!]`` in the GraphQL SDL."""
+    assert isinstance(converted, graphene.List), f"expected graphene.List, got {converted!r}"
+    item = _unwrap(converted)
+    assert isinstance(item, graphene.NonNull), (
+        f"list items must be NonNull-wrapped (i.e. [{inner_scalar.__name__}!]), got {item!r}"
+    )
+    assert _unwrap(item) is inner_scalar, f"NonNull inner type must be {inner_scalar.__name__}, got {_unwrap(item)!r}"
+
+
+def test_list_char_field_converts_to_list_non_null_string():
+    field = ListCharField(required=False)
+    _assert_list_of_non_null(convert_form_field(field), graphene.String)
+
+
+def test_list_integer_field_converts_to_list_non_null_int():
+    field = ListIntegerField(required=False)
+    _assert_list_of_non_null(convert_form_field(field), graphene.Int)
+
+
+def test_month_range_field_converts_to_string():
+    field = MonthRangeField(required=False)
+    converted = convert_form_field(field)
+    assert isinstance(converted, graphene.String)
+
+
+def test_multiple_choice_field_converts_to_list_non_null_string():
+    field = MultipleChoiceField(choices=[("a", "A")], required=False)
+    _assert_list_of_non_null(convert_form_field(field), graphene.String)
+
+
+def test_importing_apibase_without_configured_django_does_not_raise():
+    """``import apibase`` must remain safe before Django is configured.
+
+    The converter registration is intentionally guarded by a try/except so
+    that REST-only consumers, packaging scripts, and CLI tools can import
+    the package without first calling ``django.setup()``. Run in a child
+    process to guarantee a pristine settings state.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import apibase; print(apibase.__version__)"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": __import__("os").environ.get("PATH", "")},
+    )
+    assert result.returncode == 0, (
+        f"`import apibase` failed without Django settings configured:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert apibase.__version__ in result.stdout

--- a/apibase/graphql/tests/test_converters.py
+++ b/apibase/graphql/tests/test_converters.py
@@ -7,6 +7,7 @@ primary contract relied on by all ``__in`` / ``__nin`` GraphQL filters in
 downstream projects.
 """
 
+import os
 import subprocess
 import sys
 
@@ -58,17 +59,23 @@ def test_multiple_choice_field_converts_to_list_non_null_string():
 def test_importing_apibase_without_configured_django_does_not_raise():
     """``import apibase`` must remain safe before Django is configured.
 
-    The converter registration is intentionally guarded by a try/except so
-    that REST-only consumers, packaging scripts, and CLI tools can import
-    the package without first calling ``django.setup()``. Run in a child
-    process to guarantee a pristine settings state.
+    The converter registration is intentionally skipped when
+    ``settings.configured`` is False so REST-only consumers, packaging
+    scripts, and CLI tools can import the package without first calling
+    ``django.setup()``. Run in a child process to guarantee a pristine
+    settings state, but preserve the rest of the parent environment
+    (PATH, dynamic loader paths, locale, virtualenv vars) so the test
+    runs reliably across hosts and CI configurations.
     """
+    env = os.environ.copy()
+    env.pop("DJANGO_SETTINGS_MODULE", None)
+    env.pop("DJANGO_CONFIGURATION", None)
     result = subprocess.run(
         [sys.executable, "-c", "import apibase; print(apibase.__version__)"],
         capture_output=True,
         text=True,
         check=False,
-        env={"PATH": __import__("os").environ.get("PATH", "")},
+        env=env,
     )
     assert result.returncode == 0, (
         f"`import apibase` failed without Django settings configured:\n"

--- a/apibase/utils.py
+++ b/apibase/utils.py
@@ -1,17 +1,13 @@
 import re
 from urllib.parse import quote, unquote
 
-import graphene
 import six
-from django_filters.fields import MultipleChoiceField
 from django_filters.filters import RangeFilter
 from django_filters.utils import get_model_field
 from gql import Client, gql
 from graphene_django.forms.converter import convert_form_field
 from graphene_django.settings import graphene_settings
 from graphql_relay import get_offset_with_default, to_global_id
-
-from .fields import ListCharField, ListIntegerField, MonthRangeField
 
 
 def get_filtering_args_from_filterset(filterset_class, type, obvious_filters=None):
@@ -98,28 +94,6 @@ def query(query_string, schema=None, **params):
         return query_instance(query_string, **params)
 
     return gql_query(schema, query_string, **params)
-
-
-def init_converter():
-    convert_form_field.register(
-        MultipleChoiceField,
-        lambda field: graphene.List(graphene.String, required=field.required),
-    )
-
-    convert_form_field.register(
-        ListCharField,
-        lambda field: graphene.List(graphene.String, required=field.required),
-    )
-
-    convert_form_field.register(
-        ListIntegerField,
-        lambda field: graphene.List(graphene.Int, required=field.required),
-    )
-
-    convert_form_field.register(
-        MonthRangeField,
-        lambda field: graphene.String(required=field.required),
-    )
 
 
 def get_filename_from_header(header):

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,29 @@
+"""Project-root pytest configuration.
+
+Configures Django at module-import time so that importing :mod:`apibase`
+(which auto-registers graphene-django form-field converters and therefore
+imports ``graphene_django.settings``) succeeds during the conftest /
+collection phase. A late ``pytest_configure`` hook is too late here:
+sub-package conftests live inside ``apibase/`` and importing them
+triggers the ``apibase`` package init before pytest fires the hook.
+"""
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+        ],
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    django.setup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apibase"
-version = "0.2.1"
+version = "0.3.0"
 description = ""
 authors = [
     { name = "user.name", email = "gmail@hdknr.com" }

--- a/tests/test_apibase.py
+++ b/tests/test_apibase.py
@@ -2,4 +2,4 @@ from apibase import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ wheels = [
 
 [[package]]
 name = "apibase"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "channels" },


### PR DESCRIPTION
## Summary

`ListCharField` / `ListIntegerField` / `MonthRangeField` / `MultipleChoiceField` の graphene-django form-field converter を `apibase` import 時に自動登録する。

これまで converter 定義は `apibase.utils.init_converter()` の中にあったが apibase からは一度も呼ばれておらず、downstream プロジェクト (taihei-cvm-server など) で `__in` / `__nin` GraphQL フィルタが `String` 型に fallback してリスト引数を受け付けないバグの根本原因になっていた。

### 主な変更

- 新規 `apibase/graphql/converters.py` で converter を import 時に register
- `apibase/__init__.py` で `from . import graphql` を実行 (副作用で登録が走る)
- ただし `ImproperlyConfigured` を catch し、REST-only / CLI / packaging 経路で Django 未設定でも `import apibase` を壊さない
- List 要素を `graphene.NonNull` で wrap し、SDL は `[String!]` / `[Int!]` に
- `apibase.utils.init_converter()` 削除
- version: 0.2.1 → 0.3.0 (破壊的変更)
- pytest 根 conftest を新規追加 (sub-conftest 読み込み前に Django 設定が必要)

### SDL 確認

```
type Query {
  charField(arg: [String!]): String      # ListCharField(required=False)
  intField(arg: [Int!]!): String         # ListIntegerField(required=True)
}
```

### BREAKING CHANGE

- `apibase.utils.init_converter` 削除 (呼び出し箇所は調査済み、apibase / taihei-cvm-server に存在しなかった)
- 影響フィルタの GraphQL 引数型が `String` → `[String!]` (Int も同様)。文字列 (`"a,b"`) を渡していたクライアントはリスト (`["a","b"]`) に変更が必要だが、現状そのクライアントは元から `invalid_list` エラーで動いていなかったので実害なし

## Test plan

- [x] `uv run pytest` — 25 passed (新規 converter テスト 5 件 + 既存 19 + version 1)
- [x] `uv run ruff check` (新規/編集ファイル) — clean
- [x] SDL 出力を手動 dump して `[String!]` / `[Int!]!` を確認
- [x] subprocess で素の Python から `import apibase` (DJANGO_SETTINGS_MODULE 未設定) しても exit 0 を確認
- [ ] taihei-cvm-server 側で `just fetch-deps && uv sync` 後に `companyuser_set(employee_kind__nin: ["9"])` が通ることを確認 (マージ後)

## Notes

Codex adversarial review で High (`import apibase` クラッシュ) / Medium (`[String]` vs `[String!]`) の指摘を受け、両方解消済み。