### PR TITLE
feat(serializers): add NestedOrphanDeleteMixin (v0.4.0)

### DIFF
--- a/apibase/__init__.py
+++ b/apibase/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 # Eagerly trigger GraphQL form-field converter registration so that filters
 # using ListCharField / ListIntegerField surface the correct GraphQL types

--- a/apibase/serializers.py
+++ b/apibase/serializers.py
@@ -98,6 +98,89 @@ class DisplayField(fields.Field):
         return str(instance)
 
 
+class NestedOrphanDeleteMixin:
+    """Opt-in mixin for ``BaseModelSerializer`` adding orphan-delete semantics.
+
+    For every field listed in :attr:`nested_fields_orphan_delete` (which must
+    also be in :attr:`BaseModelSerializer.nested_fields`), existing nested
+    children that are *not* present in the payload are deleted after the
+    upsert pass performed by :meth:`BaseModelSerializer.update_nested`.
+
+    Behaviour matrix:
+
+    ============================= ===========================================
+    payload state                 action on existing children
+    ============================= ===========================================
+    field absent from payload     no deletion (PATCH partial preserved)
+    field present, empty list     delete all
+    field present, list of items  upsert listed, delete unlisted
+    POST (no parent instance yet) no-op (all rows are freshly created)
+    ============================= ===========================================
+
+    Supports reverse-FK and ``GenericRelation`` targets. ``OneToOneRel`` fields
+    raise ``NotImplementedError`` — orphan-delete for a 0-or-1 relation has
+    ambiguous semantics and is intentionally out of scope.
+
+    Place the mixin **before** ``BaseModelSerializer`` in the MRO::
+
+        class MySerializer(NestedOrphanDeleteMixin, BaseModelSerializer):
+            children = ChildSerializer(many=True)
+            nested_fields = ["children"]
+            nested_fields_orphan_delete = ["children"]
+    """
+
+    nested_fields_orphan_delete: list[str] = []
+
+    def update_nested_field(self, field_name, instance, validated_data, children):
+        applies = field_name in self.nested_fields_orphan_delete and instance is not None
+
+        if applies:
+            # Resolve the related field early so OneToOneRel fails loud before
+            # super() mutates the database.
+            related_field = self._resolve_nested_related_field(field_name)
+            if isinstance(related_field, OneToOneRel):
+                raise NotImplementedError("NestedOrphanDeleteMixin does not yet support OneToOneRel fields")
+
+        items = super().update_nested_field(field_name, instance, validated_data, children)
+
+        if not applies:
+            return items
+        if not self._field_explicitly_present_in_payload(field_name):
+            return items
+
+        kept_ids = {item.id for item in (items or []) if item is not None and getattr(item, "id", None) is not None}
+        manager = getattr(instance, field_name)
+        manager.exclude(id__in=kept_ids).delete()
+        return items
+
+    def _resolve_nested_related_field(self, field_name):
+        """Return the Django field/rel backing ``field_name``.
+
+        Mirrors the resolution :meth:`BaseModelSerializer.update_nested`
+        performs (strip a trailing ``_set`` and look up by relation name).
+        """
+        name = re.sub(r"(.+)(_set)$", r"\g<1>", field_name)
+        return self.Meta.model._meta.get_field(name)
+
+    def _field_explicitly_present_in_payload(self, field_name):
+        """Distinguish "field omitted from payload" from "field sent empty".
+
+        :meth:`BaseModelSerializer.run_validation` records the children set
+        in two shapes:
+
+        * dict path: every ``nested_fields`` key is present with ``None`` when
+          the payload did not include it. We treat ``None`` as "absent".
+        * QueryDict path: only keys present in the request body are added.
+          Missing keys are absent from the QueryDict.
+        """
+        children_set = getattr(self, "_children_set", None)
+        if children_set is None:
+            return False
+        if hasattr(children_set, "getlist"):
+            return field_name in children_set
+        return children_set.get(field_name) is not None
+
+
 class BaseModelSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=False)
     endpoint = EndpointField()

--- a/apibase/serializers.py
+++ b/apibase/serializers.py
@@ -99,12 +99,12 @@ class DisplayField(fields.Field):
 
 
 class NestedOrphanDeleteMixin:
-    """Opt-in mixin for ``BaseModelSerializer`` adding orphan-delete semantics.
+    """Opt-in mixin for `BaseModelSerializer` adding orphan-delete semantics.
 
-    For every field listed in :attr:`nested_fields_orphan_delete` (which must
-    also be in :attr:`BaseModelSerializer.nested_fields`), existing nested
-    children that are *not* present in the payload are deleted after the
-    upsert pass performed by :meth:`BaseModelSerializer.update_nested`.
+    For every field listed in `nested_fields_orphan_delete` (which must also
+    be in `BaseModelSerializer.nested_fields`), existing nested children that
+    are *not* present in the payload are deleted after the upsert pass
+    performed by `BaseModelSerializer.update_nested`.
 
     Behaviour matrix:
 
@@ -117,11 +117,11 @@ class NestedOrphanDeleteMixin:
     POST (no parent instance yet) no-op (all rows are freshly created)
     ============================= ===========================================
 
-    Supports reverse-FK and ``GenericRelation`` targets. ``OneToOneRel`` fields
-    raise ``NotImplementedError`` — orphan-delete for a 0-or-1 relation has
+    Supports reverse-FK and `GenericRelation` targets. `OneToOneRel` fields
+    raise `NotImplementedError` — orphan-delete for a 0-or-1 relation has
     ambiguous semantics and is intentionally out of scope.
 
-    Place the mixin **before** ``BaseModelSerializer`` in the MRO::
+    Place the mixin **before** `BaseModelSerializer` in the MRO::
 
         class MySerializer(NestedOrphanDeleteMixin, BaseModelSerializer):
             children = ChildSerializer(many=True)
@@ -154,10 +154,10 @@ class NestedOrphanDeleteMixin:
         return items
 
     def _resolve_nested_related_field(self, field_name):
-        """Return the Django field/rel backing ``field_name``.
+        """Return the Django field/rel backing `field_name`.
 
-        Mirrors the resolution :meth:`BaseModelSerializer.update_nested`
-        performs (strip a trailing ``_set`` and look up by relation name).
+        Mirrors the resolution `BaseModelSerializer.update_nested` performs
+        (strip a trailing `_set` and look up by relation name).
         """
         name = re.sub(r"(.+)(_set)$", r"\g<1>", field_name)
         return self.Meta.model._meta.get_field(name)
@@ -165,11 +165,11 @@ class NestedOrphanDeleteMixin:
     def _field_explicitly_present_in_payload(self, field_name):
         """Distinguish "field omitted from payload" from "field sent empty".
 
-        :meth:`BaseModelSerializer.run_validation` records the children set
-        in two shapes:
+        `BaseModelSerializer.run_validation` records the children set in two
+        shapes:
 
-        * dict path: every ``nested_fields`` key is present with ``None`` when
-          the payload did not include it. We treat ``None`` as "absent".
+        * dict path: every `nested_fields` key is present with `None` when
+          the payload did not include it. We treat `None` as "absent".
         * QueryDict path: only keys present in the request body are added.
           Missing keys are absent from the QueryDict.
         """

--- a/conftest.py
+++ b/conftest.py
@@ -23,7 +23,13 @@ if not settings.configured:
         INSTALLED_APPS=[
             "django.contrib.contenttypes",
             "django.contrib.auth",
+            "tests",
         ],
         DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        # No migrations for the tests app — create tables directly from
+        # model definitions via `migrate --run-syncdb` semantics. Keeps the
+        # test fixture lightweight and avoids shipping migration files for
+        # throwaway test models.
+        MIGRATION_MODULES={"tests": None},
     )
     django.setup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apibase"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 authors = [
     { name = "user.name", email = "gmail@hdknr.com" }

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class TestsConfig(AppConfig):
+    name = "tests"
+    label = "tests"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,41 @@
+from django.db import models
+
+
+class Parent(models.Model):
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        app_label = "tests"
+
+
+class Child(models.Model):
+    parent = models.ForeignKey(Parent, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100)
+    ordinal = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "tests"
+        ordering = ["ordinal", "id"]
+
+
+class OtherChild(models.Model):
+    """Second nested relation on Parent. Used to verify opt-in semantics:
+    a serializer can declare Child in nested_fields_orphan_delete while
+    leaving OtherChild untouched, even though both are in nested_fields.
+    """
+
+    parent = models.ForeignKey(Parent, on_delete=models.CASCADE)
+    label = models.CharField(max_length=100)
+
+    class Meta:
+        app_label = "tests"
+
+
+class Profile(models.Model):
+    """OneToOne reverse relation on Parent — used to verify NotImplementedError."""
+
+    parent = models.OneToOneField(Parent, on_delete=models.CASCADE)
+    bio = models.CharField(max_length=200)
+
+    class Meta:
+        app_label = "tests"

--- a/tests/test_apibase.py
+++ b/tests/test_apibase.py
@@ -2,4 +2,4 @@ from apibase import __version__
 
 
 def test_version():
-    assert __version__ == "0.3.0"
+    assert __version__ == "0.4.0"

--- a/tests/test_nested_orphan_delete.py
+++ b/tests/test_nested_orphan_delete.py
@@ -1,0 +1,210 @@
+"""Tests for `NestedOrphanDeleteMixin`.
+
+Verifies the behaviour matrix:
+
+  payload state              -> orphan-delete action
+  -------------------------------------------------
+  field absent from payload  -> no deletion (PATCH partial preserved)
+  field present, empty list  -> delete all
+  field present, list of ids -> upsert listed, delete unlisted
+  POST (no instance)         -> no-op
+
+Also verifies:
+  - opt-in: only fields listed in `nested_fields_orphan_delete` are affected
+  - OneToOneRel targets raise NotImplementedError
+"""
+
+import pytest
+
+from rest_framework import serializers
+
+from apibase.serializers import BaseModelSerializer, NestedOrphanDeleteMixin
+
+from tests.models import Child, OtherChild, Parent, Profile
+
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Serializer fixtures
+# ---------------------------------------------------------------------------
+
+
+class ChildSerializer(BaseModelSerializer):
+    class Meta:
+        model = Child
+        # `parent` must be in `fields` so apibase's `update_nested` can inject
+        # the parent FK into validated_data before save (see L210 / L304-306).
+        fields = ["id", "parent", "name", "ordinal"]
+        extra_kwargs = {"parent": {"required": False}}
+
+
+class OtherChildSerializer(BaseModelSerializer):
+    class Meta:
+        model = OtherChild
+        fields = ["id", "parent", "label"]
+        extra_kwargs = {"parent": {"required": False}}
+
+
+class ProfileSerializer(BaseModelSerializer):
+    class Meta:
+        model = Profile
+        fields = ["id", "parent", "bio"]
+        extra_kwargs = {"parent": {"required": False}}
+
+
+class ParentSerializer(NestedOrphanDeleteMixin, BaseModelSerializer):
+    """Parent serializer: orphan delete is enabled for `child_set` only.
+
+    `otherchild_set` is in nested_fields but NOT in nested_fields_orphan_delete,
+    so its children must NEVER be deleted by this mixin (regression guard).
+    """
+
+    child_set = ChildSerializer(many=True, required=False)
+    otherchild_set = OtherChildSerializer(many=True, required=False)
+
+    nested_fields = ["child_set", "otherchild_set"]
+    nested_fields_orphan_delete = ["child_set"]
+
+    class Meta:
+        model = Parent
+        fields = ["id", "name", "child_set", "otherchild_set"]
+
+
+class ParentWithProfileSerializer(NestedOrphanDeleteMixin, BaseModelSerializer):
+    """For OneToOneRel guard test."""
+
+    profile = ProfileSerializer(required=False)
+
+    nested_fields = ["profile"]
+    nested_fields_orphan_delete = ["profile"]
+
+    class Meta:
+        model = Parent
+        fields = ["id", "name", "profile"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parent_with_children():
+    parent = Parent.objects.create(name="p")
+    a = Child.objects.create(parent=parent, name="a", ordinal=1)
+    b = Child.objects.create(parent=parent, name="b", ordinal=2)
+    return parent, a, b
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_post_creates_all_children():
+    payload = {
+        "name": "new-parent",
+        "child_set": [
+            {"name": "a", "ordinal": 1},
+            {"name": "b", "ordinal": 2},
+        ],
+    }
+    ser = ParentSerializer(data=payload)
+    assert ser.is_valid(raise_exception=True)
+    parent = ser.save()
+    assert parent.child_set.count() == 2
+    assert set(parent.child_set.values_list("name", flat=True)) == {"a", "b"}
+
+
+def test_patch_updates_existing_and_deletes_orphan():
+    parent, a, b = _make_parent_with_children()
+
+    payload = {
+        "child_set": [{"id": a.id, "name": "a-renamed", "ordinal": 1}],
+    }
+    ser = ParentSerializer(instance=parent, data=payload, partial=True)
+    assert ser.is_valid(raise_exception=True)
+    ser.save()
+
+    parent.refresh_from_db()
+    remaining = list(parent.child_set.all())
+    assert len(remaining) == 1
+    assert remaining[0].id == a.id
+    assert remaining[0].name == "a-renamed"
+    assert not Child.objects.filter(id=b.id).exists()
+
+
+def test_patch_with_empty_list_deletes_all():
+    parent, a, b = _make_parent_with_children()
+
+    payload = {"child_set": []}
+    ser = ParentSerializer(instance=parent, data=payload, partial=True)
+    assert ser.is_valid(raise_exception=True)
+    ser.save()
+
+    parent.refresh_from_db()
+    assert parent.child_set.count() == 0
+    assert not Child.objects.filter(id__in=[a.id, b.id]).exists()
+
+
+def test_patch_with_field_absent_keeps_all_children():
+    parent, a, b = _make_parent_with_children()
+
+    payload = {"name": "renamed-only"}
+    ser = ParentSerializer(instance=parent, data=payload, partial=True)
+    assert ser.is_valid(raise_exception=True)
+    ser.save()
+
+    parent.refresh_from_db()
+    assert parent.name == "renamed-only"
+    assert set(parent.child_set.values_list("id", flat=True)) == {a.id, b.id}
+
+
+def test_patch_with_new_child_no_id_creates_and_deletes_existing():
+    parent, a, b = _make_parent_with_children()
+
+    payload = {"child_set": [{"name": "c", "ordinal": 3}]}
+    ser = ParentSerializer(instance=parent, data=payload, partial=True)
+    assert ser.is_valid(raise_exception=True)
+    ser.save()
+
+    parent.refresh_from_db()
+    remaining = list(parent.child_set.all())
+    assert len(remaining) == 1
+    assert remaining[0].name == "c"
+    assert not Child.objects.filter(id__in=[a.id, b.id]).exists()
+
+
+def test_orphan_delete_only_applies_to_listed_fields():
+    """`otherchild_set` is in nested_fields but NOT in nested_fields_orphan_delete.
+
+    Even when the payload omits otherchild_set, its existing rows must not be
+    deleted. And when an empty list is sent for otherchild_set, the mixin must
+    NOT cascade-delete them (because the user did not opt in for that field).
+    """
+    parent = Parent.objects.create(name="p")
+    Child.objects.create(parent=parent, name="kept-child", ordinal=1)
+    other_a = OtherChild.objects.create(parent=parent, label="x")
+    other_b = OtherChild.objects.create(parent=parent, label="y")
+
+    payload = {"otherchild_set": []}
+    ser = ParentSerializer(instance=parent, data=payload, partial=True)
+    assert ser.is_valid(raise_exception=True)
+    ser.save()
+
+    parent.refresh_from_db()
+    surviving_other_ids = set(parent.otherchild_set.values_list("id", flat=True))
+    assert surviving_other_ids == {other_a.id, other_b.id}
+
+
+def test_one_to_one_rel_raises_not_implemented():
+    parent = Parent.objects.create(name="p")
+    Profile.objects.create(parent=parent, bio="old bio")
+
+    payload = {"profile": {"bio": "new bio"}}
+    ser = ParentWithProfileSerializer(instance=parent, data=payload, partial=True)
+    assert ser.is_valid(raise_exception=True)
+
+    with pytest.raises(NotImplementedError, match="OneToOneRel"):
+        ser.save()

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ wheels = [
 
 [[package]]
 name = "apibase"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "channels" },


### PR DESCRIPTION
## Summary

- 新規 `NestedOrphanDeleteMixin` を `apibase/serializers.py` に追加
- 既存 `BaseModelSerializer.nested_fields` 経由の writable nested に **orphan delete** セマンティクスを opt-in で付与
- バージョン `0.3.0` → `0.4.0`

## Why

`spin-dd/taihei-cvm-server#489` で要求された差分置換セマンティクス:

- child without `id` → create
- child with matching `id` → update
- existing child absent from payload → **delete**

3 つ目を提供する mixin が無かったため追加。1 つ目・2 つ目は既存 `update_nested` がカバー。

## Behaviour matrix

| payload state | action |
|---------------|--------|
| field absent from payload | no deletion (PATCH partial preserved) |
| field present, empty list | delete all |
| field present, list of items | upsert listed, delete unlisted |
| POST (no parent instance yet) | no-op |

- reverse-FK / GenericRelation サポート
- OneToOneRel は `NotImplementedError` で fail-loud（ambiguous semantics のため意図的に out of scope）

## Usage

```python
from apibase.serializers import BaseModelSerializer, NestedOrphanDeleteMixin

class MySerializer(NestedOrphanDeleteMixin, BaseModelSerializer):
    children = ChildSerializer(many=True, required=False)
    nested_fields = ["children"]
    nested_fields_orphan_delete = ["children"]
```

`nested_fields_orphan_delete` を指定しない既存 serializer は **完全に従来挙動を維持** (opt-in なので regression なし)。

## Test plan

- [x] `tests/test_nested_orphan_delete.py` 新規追加 — 7 シナリオ（POST, PATCH update, empty list, absent key, new + orphan delete, opt-in 限定, OneToOneRel guard）
- [x] `tests/test_apibase.py` バージョン assertion 更新
- [x] `tests/apps.py` + `tests/models.py` テスト app + Parent/Child/OtherChild/Profile モデル
- [x] `conftest.py` に `MIGRATION_MODULES = {"tests": None}` を追加（syncdb モードで test テーブル生成）
- [x] `uv run pytest tests/` → **8/8 passed**

## Follow-up

merge 後に annotated tag `v0.4.0` を打つこと → `taihei-approvals` と `taihei-cvm-server` 側の依存ピン更新を続ける（taihei-cvm-server#489 で chain）。

For taihei-cvm-server#489.