### PR TITLE
fix: honor DRF save(**kwargs) contract in BaseModelSerializer

### DIFF
--- a/apibase/serializers.py
+++ b/apibase/serializers.py
@@ -204,11 +204,13 @@ class BaseModelSerializer(serializers.ModelSerializer):
         action = self._get_action(self.view_action)
         action and action.validate()
 
-    def _save_for_action(self):
+    def _save_for_action(self, **kwargs):
         action = self._get_action(self.view_action)
         if action:
             return action.save(super())
-        return super().save()
+        # Honor DRF's `serializer.save(**extra)` contract: forward extra
+        # attributes (e.g. perform_create defaults) into the saved instance.
+        return super().save(**kwargs)
 
     def is_valid(self, raise_exception=False):
         """(override)"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apibase"
-version = "0.4.0"
+version = "0.4.1"
 description = ""
 authors = [
     { name = "user.name", email = "gmail@hdknr.com" }


### PR DESCRIPTION
## What
`BaseModelSerializer.save(**kwargs)` delegated to `_save_for_action(**kwargs)`, but `_save_for_action(self)` took no kwargs — so the standard DRF pattern `serializer.save(**extra)` (e.g. `perform_create` injecting default attributes) raised `TypeError: _save_for_action() got an unexpected keyword argument`.

## Fix
Forward kwargs to `super().save(**kwargs)` in the no-action path. Backward compatible:
- no-kwargs path → identical to before (`super().save()`)
- action path → unchanged (`action.save(super())`)
- only the previously-broken no-action + kwargs path now works

## Why
Downstream `taihei-prm-server` hit this when rebasing its `InquiryViewSet.perform_create` (which injects `requester_code`/`requester_name` via `serializer.save(**extra)`) onto apibase. Fixed upstream rather than worked around per project policy.

## Verification
apibase own test suite: 32 passed. Patch bump 0.4.0 → 0.4.1.

https://claude.ai/code/session_018iXiqd8D8rp6tVbuJXUw96