### PR TITLE
chore: modernize string formatting in settings.py (UP031, C402)

### DIFF
--- a/apibase/settings/settings.py
+++ b/apibase/settings/settings.py
@@ -23,7 +23,7 @@ def import_from_string(val, setting_name):
     try:
         return import_string(val)
     except ImportError as e:
-        msg = "Could not import '%s' for API setting '%s'. %s: %s." % (val, setting_name, e.__class__.__name__, e)
+        msg = f"Could not import '{val}' for API setting '{setting_name}'. {e.__class__.__name__}: {e}."
         raise ImportError(msg)
 
 
@@ -39,7 +39,7 @@ class Settings:
 
     def __getattr__(self, attr):
         if attr not in self.defaults:
-            raise AttributeError("Invalid API setting: '%s'" % attr)
+            raise AttributeError(f"Invalid API setting: '{attr}'")
 
         val = self.user_settings.get(attr, None)
         val_default = self.defaults.get(attr, None)
@@ -75,7 +75,7 @@ class Settings:
     def create(cls, name, default_tuple):
         return cls(
             getattr(dj_settings, name, None),
-            dict((i[0], i[1][1]) for i in default_tuple),
+            {i[0]: i[1][1] for i in default_tuple},
             [i[0] for i in default_tuple if i[1][0]],
             name=name,
         )

--- a/apibase/settings/settings.py
+++ b/apibase/settings/settings.py
@@ -23,7 +23,7 @@ def import_from_string(val, setting_name):
     try:
         return import_string(val)
     except ImportError as e:
-        msg = f"Could not import '{val}' for API setting '{setting_name}'. {e.__class__.__name__}: {e}."
+        msg = f"Could not import '{val!s}' for API setting '{setting_name!s}'. {e.__class__.__name__}: {e!s}."
         raise ImportError(msg)
 
 
@@ -39,7 +39,7 @@ class Settings:
 
     def __getattr__(self, attr):
         if attr not in self.defaults:
-            raise AttributeError(f"Invalid API setting: '{attr}'")
+            raise AttributeError(f"Invalid API setting: '{attr!s}'")
 
         val = self.user_settings.get(attr, None)
         val_default = self.defaults.get(attr, None)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,6 +28,20 @@ def test_unknown_attribute_raises_attribute_error():
         _ = apibase_settings.DOES_NOT_EXIST
 
 
+def test_import_error_message_uses_str_not_format():
+    from apibase.settings.settings import import_from_string
+
+    class _WeirdStr(str):
+        def __format__(self, spec):
+            return "FORMATTED"
+
+    with pytest.raises(ImportError) as exc:
+        import_from_string(_WeirdStr("does.not.exist.Thing"), "SOME_SETTING")
+    msg = str(exc.value)
+    assert "does.not.exist.Thing" in msg
+    assert "FORMATTED" not in msg
+
+
 # ---------------------------------------------------------------------------
 # SET-001 override_settings(APIBASE=...) is honoured via a setting_changed reload
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要
`apibase/settings/settings.py` の既存 ruff 指摘（PR #12 以前から存在）を解消。挙動変更なし。

- UP031 ×2: percent-format → f-string（文言・クォートは同一）
- C402: `dict((...) for ...)` → dict 内包表記

## Test plan
- [x] `uv run ruff check apibase/settings/` クリーン
- [x] `uv run pytest -q` → 132 passed（挙動不変）

> Base は #12（`test/apibase-nocov-coverage`）にスタック。#12 マージ後に自動 retarget。

https://claude.ai/code/session_01BwQxJWkWr7wuDCHj8zmwoM